### PR TITLE
Add basic crypto money pot features

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -2,10 +2,9 @@
   <div>
     <NuxtRouteAnnouncer />
     <NuxtPage />
-    <NuxtWelcome />
   </div>
 </template>
 
 <script setup lang="ts">
-import { NuxtRouteAnnouncer, NuxtPage, NuxtWelcome } from "#components";
+import { NuxtRouteAnnouncer, NuxtPage } from '#components';
 </script>

--- a/app/pages/cagnottes/[id]/contribute.vue
+++ b/app/pages/cagnottes/[id]/contribute.vue
@@ -1,0 +1,24 @@
+<template>
+  <div>
+    <h2>Contribuer</h2>
+    <form @submit.prevent="contribute">
+      <input v-model="amount" placeholder="Montant" />
+      <button type="submit">Envoyer</button>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { navigateTo, useRoute } from '#app';
+const amount = ref('');
+const { id } = useRoute().params as { id: string };
+
+const contribute = async () => {
+  await $fetch(`/api/pots/${id}/contribute`, {
+    method: 'POST',
+    body: { amount: amount.value, txHash: '0x' },
+  });
+  await navigateTo(`/cagnottes/${id}`);
+};
+</script>

--- a/app/pages/cagnottes/[id]/index.vue
+++ b/app/pages/cagnottes/[id]/index.vue
@@ -1,0 +1,12 @@
+<template>
+  <div>
+    <h2>{{ pot?.title }}</h2>
+    <p>Montant: {{ pot?.amount }}</p>
+    <a :href="`/cagnottes/${id}/contribute`">Contribuer</a>
+  </div>
+</template>
+
+<script setup lang="ts">
+const { id } = useRoute().params as { id: string };
+const { data: pot } = await useFetch(`/api/pots/${id}`);
+</script>

--- a/app/pages/cagnottes/create.vue
+++ b/app/pages/cagnottes/create.vue
@@ -1,0 +1,21 @@
+<template>
+  <div>
+    <h2>Creer une cagnotte</h2>
+    <form @submit.prevent="createPot">
+      <input v-model="title" placeholder="Titre" />
+      <button type="submit">Creer</button>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { navigateTo } from '#app';
+
+const title = ref('');
+
+const createPot = async () => {
+  const { pot } = await $fetch('/api/pots/create', { method: 'POST', body: { title: title.value } });
+  await navigateTo(`/cagnottes/${pot.id}`);
+};
+</script>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,76 +1,10 @@
 <template>
-  <div class="flex min-h-screen items-center justify-center bg-gray-100">
-    <div class="w-full max-w-md bg-white p-8 rounded-lg shadow-md">
-      <h2 class="text-2xl font-bold text-center mb-6">Login</h2>
-      
-      <form @submit.prevent="handleLogin">
-        <div class="mb-4">
-          <label for="email" class="block text-sm font-medium">Email</label>
-          <input 
-            v-model="email" 
-            type="email" 
-            id="email" 
-            required 
-            class="w-full mt-1 p-2 border rounded-md"
-          />
-        </div>
-
-        <div class="mb-4">
-          <label for="password" class="block text-sm font-medium">Password</label>
-          <input 
-            v-model="password" 
-            type="password" 
-            id="password" 
-            required 
-            class="w-full mt-1 p-2 border rounded-md"
-          />
-        </div>
-
-        <button 
-          type="submit" 
-          class="w-full bg-blue-500 text-white py-2 rounded-md hover:bg-blue-600"
-          :disabled="loading"
-        >
-          {{ loading ? 'Logging in...' : 'Login' }}
-        </button>
-
-        <p v-if="errorMessage" class="text-red-500 text-sm mt-2">{{ errorMessage }}</p>
-      </form>
-    </div>
+  <div>
+    <h1>Crypto MoneyPot</h1>
+    <p>Creez et contribuez a des cagnottes crypto en toute simplicite.</p>
+    <nav>
+      <a href="/register">Inscription</a> |
+      <a href="/login">Connexion</a>
+    </nav>
   </div>
 </template>
-
-<script setup lang="ts">
-import { useAuth } from "#imports";
-import { ref } from "vue";
-import { useRouter } from "vue-router";
-
-const email = ref("");
-const password = ref("");
-const loading = ref(false);
-const errorMessage = ref("");
-const auth = useAuth();
-const router = useRouter();
-
-const handleLogin = async () => {
-	loading.value = true;
-	errorMessage.value = "";
-
-	try {
-		const register = await auth.signUp.email({
-			email: email.value,
-			password: password.value,
-			name: email.value,
-		});
-		router.push("/?auth=success"); // Redirect after successful login
-		if (register.error) {
-			errorMessage.value =
-				register.error.message ?? "Invalid login credentials";
-		}
-	} catch (error) {
-		errorMessage.value = "unhandled error";
-	} finally {
-		loading.value = false;
-	}
-};
-</script>

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -1,0 +1,8 @@
+<template>
+  <div>
+    <h2>Connexion</h2>
+    <form method="post" action="/api/auth/github">
+      <button type="submit">Se connecter avec GitHub</button>
+    </form>
+  </div>
+</template>

--- a/app/pages/profile.vue
+++ b/app/pages/profile.vue
@@ -1,0 +1,22 @@
+<template>
+  <div>
+    <h2>Profil</h2>
+    <p v-if="user">Email: {{ user.email }}</p>
+    <form @submit.prevent="linkWallet">
+      <input v-model="wallet" placeholder="Adresse du wallet" />
+      <button type="submit">Associer</button>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useAuth } from '#imports';
+
+const { user } = useAuth();
+const wallet = ref('');
+
+const linkWallet = async () => {
+  await $fetch('/api/wallet/link', { method: 'POST', body: { walletAddress: wallet.value } });
+};
+</script>

--- a/app/pages/register.vue
+++ b/app/pages/register.vue
@@ -1,0 +1,8 @@
+<template>
+  <div>
+    <h2>Inscription</h2>
+    <form method="post" action="/api/auth/github">
+      <button type="submit">Se connecter avec GitHub</button>
+    </form>
+  </div>
+</template>

--- a/server/api/auth/github.ts
+++ b/server/api/auth/github.ts
@@ -1,0 +1,6 @@
+import { defineEventHandler, toWebRequest } from 'h3';
+import { auth } from '../../lib/auth';
+
+export default defineEventHandler((event) => {
+  return auth.handler(toWebRequest(event));
+});

--- a/server/api/pots/[id].ts
+++ b/server/api/pots/[id].ts
@@ -1,0 +1,21 @@
+import { defineEventHandler, createError } from 'h3';
+import { db } from '../../database/db';
+import { pots, contributions } from '../../database/schemas';
+import { eq, sum } from 'drizzle-orm';
+
+export default defineEventHandler(async (event) => {
+  const id = Number(event.context.params?.id);
+  if (!id) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid id' });
+  }
+  const pot = await db.query.pots.findFirst({ where: eq(pots.id, id) });
+  if (!pot) {
+    throw createError({ statusCode: 404, statusMessage: 'Not found' });
+  }
+  const totalResult = await db
+    .select({ total: sum(contributions.amount) })
+    .from(contributions)
+    .where(eq(contributions.potId, id));
+  const total = totalResult[0]?.total || '0';
+  return { pot: { ...pot, amount: total } };
+});

--- a/server/api/pots/[id]/contribute.ts
+++ b/server/api/pots/[id]/contribute.ts
@@ -1,0 +1,20 @@
+import { defineEventHandler, readBody, createError } from 'h3';
+import { db } from '../../../database/db';
+import { contributions } from '../../../database/schemas';
+
+export default defineEventHandler(async (event) => {
+  const id = Number(event.context.params?.id);
+  const { amount, txHash } = await readBody<{ amount: string; txHash: string }>(event);
+  const session = event.context.user;
+  if (!session) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' });
+  }
+  if (!id) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid id' });
+  }
+  const [contribution] = await db
+    .insert(contributions)
+    .values({ potId: id, contributorId: session.id, amount, txHash })
+    .returning();
+  return { contribution };
+});

--- a/server/api/pots/create.ts
+++ b/server/api/pots/create.ts
@@ -1,0 +1,16 @@
+import { defineEventHandler, readBody, createError } from 'h3';
+import { db } from '../../database/db';
+import { pots } from '../../database/schemas';
+
+export default defineEventHandler(async (event) => {
+  const { title } = await readBody<{ title: string }>(event);
+  const session = event.context.user;
+  if (!session) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' });
+  }
+  const [pot] = await db
+    .insert(pots)
+    .values({ title, creatorId: session.id })
+    .returning();
+  return { pot };
+});

--- a/server/api/wallet/link.ts
+++ b/server/api/wallet/link.ts
@@ -1,0 +1,14 @@
+import { defineEventHandler, readBody, createError } from 'h3';
+import { db } from '../database/db';
+import { users } from '../database/schemas';
+import { eq } from 'drizzle-orm';
+
+export default defineEventHandler(async (event) => {
+  const { walletAddress } = await readBody<{ walletAddress: string }>(event);
+  const session = event.context.user;
+  if (!session) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' });
+  }
+  await db.update(users).set({ walletAddress }).where(eq(users.id, session.id));
+  return { success: true };
+});

--- a/server/database/schemas/index.ts
+++ b/server/database/schemas/index.ts
@@ -1,1 +1,2 @@
 export * from "./auth-schemas";
+export * from "./moneypot";

--- a/server/database/schemas/moneypot.ts
+++ b/server/database/schemas/moneypot.ts
@@ -1,0 +1,23 @@
+import { pgTable, serial, integer, text, timestamp } from "drizzle-orm/pg-core";
+
+export const users = pgTable("users", {
+  id: serial("id").primaryKey(),
+  email: text("email").notNull().unique(),
+  githubId: text("github_id").notNull().unique(),
+  walletAddress: text("wallet_address"),
+});
+
+export const pots = pgTable("pots", {
+  id: serial("id").primaryKey(),
+  title: text("title").notNull(),
+  creatorId: integer("creator_id").references(() => users.id).notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+export const contributions = pgTable("contributions", {
+  id: serial("id").primaryKey(),
+  potId: integer("pot_id").references(() => pots.id).notNull(),
+  contributorId: integer("contributor_id").references(() => users.id).notNull(),
+  amount: text("amount").notNull(),
+  txHash: text("tx_hash").notNull(),
+});

--- a/server/lib/auth.ts
+++ b/server/lib/auth.ts
@@ -4,6 +4,7 @@ import { createStorage } from "unstorage";
 import fsDriver from "unstorage/drivers/fs";
 import { db } from "../database/db";
 import * as authSchemas from "../database/schemas/auth-schemas";
+import github from "better-auth/providers/github";
 
 // const storage = createStorage({
 //     driver: fsDriver({ base: "./.data" }),
@@ -25,7 +26,8 @@ export const auth = betterAuth({
 	//     },
 	//     delete: key => storage.del(`_auth:${key}`),
 	// },
-	emailAndPassword: {
-		enabled: true,
-	},
+        providers: [github()],
+        emailAndPassword: {
+                enabled: true,
+        },
 });


### PR DESCRIPTION
## Summary
- add simple marketing homepage and profile/wallet pages
- add pages to create and contribute to pots
- integrate GitHub auth route and wallet/pot API routes
- define Drizzle schema for users, pots and contributions

## Testing
- `pnpm build` *(fails: Request was cancelled due to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686282270c3c832aa835392f687aa490