### PR TITLE
Add RPC support for local blockchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,25 @@ yarn dev
 bun run dev
 ```
 
+## Local Blockchain
+
+This project ships with a minimal [Hardhat](https://hardhat.org/) setup for
+running a local Ethereum network. Start it in a separate terminal with:
+
+```bash
+pnpm hardhat:node
+```
+
+By default the app connects via a browser wallet (`window.ethereum`). If you
+prefer to connect directly to the local node, create a `.env` file and set
+
+```
+NUXT_PUBLIC_RPC_URL=http://127.0.0.1:8545
+```
+
+Restart the dev server and the app will use this JSON‑RPC endpoint instead of a
+browser wallet.
+
 ## Production
 
 Build the application for production:

--- a/app/composables/useWallet.ts
+++ b/app/composables/useWallet.ts
@@ -11,7 +11,15 @@ export function useWallet() {
     if (!provider) {
       throw new Error("Ethereum provider not found");
     }
-    const accounts = await provider.send("eth_requestAccounts", []);
+    let accounts: string[];
+    try {
+      accounts = await (provider as ethers.BrowserProvider).send(
+        "eth_requestAccounts",
+        []
+      );
+    } catch {
+      accounts = await provider.listAccounts();
+    }
     address.value = accounts[0] as string;
     return address.value;
   }

--- a/app/plugins/ethers.client.ts
+++ b/app/plugins/ethers.client.ts
@@ -1,10 +1,15 @@
-import { defineNuxtPlugin } from "#imports";
+import { defineNuxtPlugin, useRuntimeConfig } from "#imports";
 import { ethers } from "ethers";
 
 export default defineNuxtPlugin(() => {
-  let provider: ethers.BrowserProvider | null = null;
-  if (process.client && (window as any).ethereum) {
-    provider = new ethers.BrowserProvider((window as any).ethereum);
+  const config = useRuntimeConfig();
+  let provider: ethers.BrowserProvider | ethers.JsonRpcProvider | null = null;
+  if (process.client) {
+    if (config.public.rpcUrl) {
+      provider = new ethers.JsonRpcProvider(config.public.rpcUrl as string);
+    } else if ((window as any).ethereum) {
+      provider = new ethers.BrowserProvider((window as any).ethereum);
+    }
   }
   return {
     provide: {

--- a/contracts/SimpleStorage.sol
+++ b/contracts/SimpleStorage.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+contract SimpleStorage {
+    uint256 private value;
+
+    function set(uint256 _value) external {
+        value = _value;
+    }
+
+    function get() external view returns (uint256) {
+        return value;
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,0 +1,8 @@
+import { HardhatUserConfig } from "hardhat/config";
+import "@nomicfoundation/hardhat-toolbox";
+
+const config: HardhatUserConfig = {
+  solidity: "0.8.24",
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "nuxt build",
     "dev": "nuxt dev",
+    "hardhat:node": "hardhat node",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
@@ -24,6 +25,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.0.6",
+    "hardhat": "^2.23.0",
+    "@nomicfoundation/hardhat-toolbox": "^3.0.0",
     "@nuxt/devtools": "^2.1.0",
     "@nuxt/devtools-kit": "^2.1.0",
     "drizzle-kit": "^0.30.4",


### PR DESCRIPTION
## Summary
- update ethers plugin to use `NUXT_PUBLIC_RPC_URL`
- adapt wallet composable for JsonRpcProvider
- document how to connect directly to Hardhat node

## Testing
- `npx --no-install biome format README.md app/plugins/ethers.client.ts app/composables/useWallet.ts package.json hardhat.config.ts contracts/SimpleStorage.sol` *(fails: 403 Forbidden)*
- `pnpm exec biome format README.md app/plugins/ethers.client.ts app/composables/useWallet.ts package.json hardhat.config.ts contracts/SimpleStorage.sol --write` *(fails: network error)*


------
https://chatgpt.com/codex/tasks/task_e_6862a7c95be4832a9d35b841cb3ab29c