### PR TITLE
Add contributions endpoint

### DIFF
--- a/app/pages/pots/[id].vue
+++ b/app/pages/pots/[id].vue
@@ -1,14 +1,43 @@
 <script lang="ts" setup>
-import { computed, useLazyAsyncData, useRoute } from "#imports";
+import { computed, useLazyAsyncData, useRoute, ref } from "#imports";
 
 const route = useRoute();
 const moneypotId = computed(() => route.params.id as string);
 
-const { data } = useLazyAsyncData(moneypotId, () =>
+const { data, refresh } = useLazyAsyncData(moneypotId, () =>
   $fetch(`/api/pots/${moneypotId.value}`),
 );
+
+const amount = ref("");
+const txHash = ref("");
+
+async function sendContribution() {
+  if (!amount.value || !txHash.value) return;
+  await $fetch(`/api/pots/${moneypotId.value}/contribute`, {
+    method: "POST",
+    body: { amount: amount.value, txHash: txHash.value },
+  });
+  // Refresh data
+  await refresh();
+  amount.value = "";
+  txHash.value = "";
+}
 </script>
 
 <template>
-  <pre>{{ data }}</pre>
+  <div v-if="data">
+    <h2>{{ data.pot.title }}</h2>
+    <h3>Contributions</h3>
+    <ul>
+      <li v-for="c in data.contributions" :key="c.id">
+        {{ c.contributorId }} - {{ c.amount }} ({{ c.txHash }})
+      </li>
+    </ul>
+    <form @submit.prevent="sendContribution">
+      <input v-model="amount" placeholder="Amount" />
+      <input v-model="txHash" placeholder="Tx Hash" />
+      <button type="submit">Contribute</button>
+    </form>
+  </div>
+  <div v-else>Loading...</div>
 </template>

--- a/server/api/pots/[id].get.ts
+++ b/server/api/pots/[id].get.ts
@@ -1,12 +1,23 @@
-import { defineEventHandler, readBody, createError } from "h3";
+import { defineEventHandler } from "h3";
 import { db } from "../../database/db";
-import { pots } from "../../database/schemas";
-import { auth } from "~~/server/lib/auth";
+import { pots, contributions } from "../../database/schemas";
+import { eq } from "drizzle-orm";
 
 export default defineEventHandler(async (event) => {
-  return db.query.pots.findFirst({
+  const potId = Number(event.context.params.id);
+
+  const pot = await db.query.pots.findFirst({
     where(pots, { eq }) {
-      return eq(pots.id, event.context.params.id);
+      return eq(pots.id, potId);
     },
   });
+
+  if (!pot) return null;
+
+  const potContributions = await db
+    .select()
+    .from(contributions)
+    .where(eq(contributions.potId, potId));
+
+  return { pot, contributions: potContributions };
 });

--- a/server/api/pots/[id]/contribute.post.ts
+++ b/server/api/pots/[id]/contribute.post.ts
@@ -1,0 +1,34 @@
+import { defineEventHandler, readBody, createError } from "h3";
+import { db } from "../../database/db";
+import { contributions, pots } from "../../database/schemas";
+import { auth } from "~~/server/lib/auth";
+import { eq } from "drizzle-orm";
+
+export default defineEventHandler(async (event) => {
+  const potId = Number(event.context.params.id);
+  const { amount, txHash } = await readBody<{ amount: string; txHash: string }>(event);
+
+  if (!amount || !txHash) {
+    throw createError({ statusCode: 400, statusMessage: "Missing amount or txHash" });
+  }
+
+  const session = await auth.api.getSession({ headers: event.headers });
+  if (!session) {
+    throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+  }
+
+  const exists = await db
+    .select({ id: pots.id })
+    .from(pots)
+    .where(eq(pots.id, potId));
+  if (exists.length === 0) {
+    throw createError({ statusCode: 404, statusMessage: "Moneypot not found" });
+  }
+
+  const [contribution] = await db
+    .insert(contributions)
+    .values({ potId, contributorId: session.user.id, amount, txHash })
+    .returning();
+
+  return { contribution };
+});


### PR DESCRIPTION
## Summary
- add new endpoint to store contributions
- extend pot API to return contributions
- show contributions and form on pot page

## Testing
- `pnpm format` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_6864528369b4832ab86398f1da40ddb7