### PR TITLE
Add sample data seeder

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ pnpm hardhat:node
 Then connect your browser wallet (e.g. MetaMask) to `http://127.0.0.1:8545` and
 use the accounts provided by Hardhat for testing contract interactions.
 
+## Database Seeding
+
+After running migrations, populate the local database with example data:
+
+```bash
+pnpm db:seed
+```
+
+This command inserts five demo users and creates three pots for each user.
+
 ## Production
 
 Build the application for production:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ After running migrations, populate the local database with example data:
 pnpm db:seed
 ```
 
-This command inserts five demo users and creates three pots for each user.
+This command runs the seeding script with [jiti](https://github.com/nuxt/jiti)
+and inserts five demo users with three pots each.
 
 ## Production
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "format": "pnpm exec biome format --write",
     "db:generate": "npx @better-auth/cli generate --config server/lib/auth.ts --output server/database/schemas/auth-schemas.ts && npx drizzle-kit generate",
     "db:migrate": "npx drizzle-kit migrate"
+    ,
+    "db:seed": "pnpm exec ts-node server/database/seed.ts"
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.2.17",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "db:generate": "npx @better-auth/cli generate --config server/lib/auth.ts --output server/database/schemas/auth-schemas.ts && npx drizzle-kit generate",
     "db:migrate": "npx drizzle-kit migrate"
     ,
-    "db:seed": "pnpm exec ts-node server/database/seed.ts"
+    "db:seed": "pnpm exec jiti server/database/seed.ts"
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.2.17",

--- a/server/database/seed.ts
+++ b/server/database/seed.ts
@@ -1,0 +1,43 @@
+import { db } from "./db";
+import { user, pots } from "./schemas";
+import { Wallet } from "ethers";
+
+async function seed() {
+  const users = [
+    { id: crypto.randomUUID(), name: "Alice Dupont", email: "alice@example.com" },
+    { id: crypto.randomUUID(), name: "Bob Martin", email: "bob@example.com" },
+    { id: crypto.randomUUID(), name: "Charlie Petit", email: "charlie@example.com" },
+    { id: crypto.randomUUID(), name: "Diane Leroy", email: "diane@example.com" },
+    { id: crypto.randomUUID(), name: "Eric Gauthier", email: "eric@example.com" },
+  ];
+
+  for (const u of users) {
+    const [created] = await db.insert(user).values(u).returning();
+
+    const titles = [
+      `Voyage de ${u.name.split(" ")[0]}`,
+      `Anniversaire de ${u.name.split(" ")[0]}`,
+      `Projet caritatif de ${u.name.split(" ")[0]}`,
+    ];
+
+    for (const title of titles) {
+      const wallet = Wallet.createRandom();
+      await db.insert(pots).values({
+        title,
+        creatorId: created.id,
+        walletAddress: wallet.address,
+        walletPrivateKey: wallet.privateKey,
+      });
+    }
+  }
+}
+
+seed()
+  .then(() => {
+    console.log("Seeding completed");
+    process.exit(0);
+  })
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- add a simple database seeding script
- expose `db:seed` command in package.json
- document how to seed the DB in the README

## Testing
- `pnpm exec biome format --write README.md package.json server/database/seed.ts` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_6865a4901364832a9bfeaed06baedf8d