### PR TITLE
Add search and filters on explore

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -4,7 +4,7 @@
     <UApp>
       <TheHeader />
 
-      <NuxtPage class="max-w-5xl mx-auto grow" />
+      <NuxtPage class="max-w-5xl mx-auto grow w-full" />
       <TheFooter />
     </UApp>
   </div>

--- a/app/components/ExploreFilterForm.vue
+++ b/app/components/ExploreFilterForm.vue
@@ -1,0 +1,34 @@
+<template>
+  <UForm :schema="schema" :state="{ search: searchModel, category: categoryModel }" @submit="onSubmit">
+    <div class="flex items-end gap-2">
+      <UInput v-model="searchModel" placeholder="Search" class="w-64 grow" size="xl" />
+      <USelect v-model="categoryModel" :items="categoryOptions" placeholder="Category" class="w-48" size="xl" />
+      <UButton type="submit" size="xl">Search</UButton>
+    </div>
+  </UForm>
+</template>
+
+<script setup lang="ts">
+import { UForm, UInput, USelect, UButton } from '#components';
+import * as z from 'zod';
+
+const searchModel = defineModel<string>('search');
+const categoryModel = defineModel<string>('category');
+
+const props = defineProps<{
+  categoryOptions: Array<{ label: string; value: string }>;
+}>();
+
+const emit = defineEmits<{
+  (e: 'submit'): void;
+}>();
+
+const schema = z.object({
+  search: z.string().optional(),
+  category: z.string().optional(),
+});
+
+function onSubmit() {
+  emit('submit');
+}
+</script>

--- a/app/pages/explore.vue
+++ b/app/pages/explore.vue
@@ -1,38 +1,44 @@
 <template>
   <div>
-    <div class="background bg-neutral-700 px-4">
-      <h1 class="text-3xl font-bold pt-4">Explore Moneypots</h1>
-      <p class="mt-2">Discover and contribute to moneypots created by others.</p>
-      <div class="flex items-end gap-2 mt-4 pb-4">
-        <UInput size="xl" v-model="localSearch" placeholder="Search" class="grow" />
-        <USelect size="xl" v-model="localCategory" :items="categoryOptions" placeholder="Category" class="w-52" />
-        <UButton size="xl" @click="applyFilters">Search</UButton>
+    <div class="background bg-neutral-700">
+      <div class="max-w-2xl mx-auto">
+        <h1 class="text-3xl font-bold pt-4">Explore Moneypots</h1>
+        <p class="mt-2">Discover and contribute to moneypots created by others.</p>
+        <ExploreFilterForm v-model:search="localSearch" v-model:category="localCategory"
+          :category-options="categoryOptions" @submit="applyFilters" class="py-4" />
       </div>
     </div>
-    <ul v-if="visibleMoneypots" class="grid grid-cols-5 gap-4 mt-8">
-      <li v-for="moneypot in visibleMoneypots.pots" :key="moneypot.id">
-        <NuxtLinkLocale :to="{
-          name: 'pots-id',
-          params: {
-            id: moneypot.id
-          }
-        }">
-          <MoneypotCard v-bind="getUIPropsFromMoneypot(moneypot)" class=""></MoneypotCard>
-        </NuxtLinkLocale>
-      </li>
-    </ul>
+
+    <div v-if="visibleMoneypots">
+      <div v-if="visibleMoneypots.pots.length === 0">no results</div>
+      <ul v-else class="grid grid-cols-5 gap-4 mt-8">
+        <li v-for="moneypot in visibleMoneypots.pots" :key="moneypot.id">
+          <NuxtLinkLocale :to="{
+            name: 'pots-id',
+            params: {
+              id: moneypot.id
+            }
+          }">
+            <MoneypotCard v-bind="getUIPropsFromMoneypot(moneypot)" class=""></MoneypotCard>
+          </NuxtLinkLocale>
+        </li>
+      </ul>
+    </div>
+
+
     <UPagination class="my-6" v-model:page="pageAsInt" show-edges :items-per-page="pageSize"
       :total="visibleMoneypots?.total" />
-
   </div>
 </template>
 
 
 <script setup lang="ts">
 import { useAsyncData } from "#app";
-import { NuxtLinkLocale, UPagination, UInput, USelect } from "#components";
+import { NuxtLinkLocale, UPagination } from "#components";
 import { computed, watch, ref } from "vue";
 import MoneypotCard from "~/components/MoneypotCard.vue";
+import ExploreFilterForm from "~/components/ExploreFilterForm.vue";
+
 import { useUrlParams } from "~/composables/useUrlParams";
 import { getUIPropsFromMoneypot } from "~/helpers/moneypotUIHelpers";
 

--- a/app/pages/explore.vue
+++ b/app/pages/explore.vue
@@ -1,5 +1,16 @@
 <template>
   <div>
+    <div class="flex gap-4">
+      <UInput v-model="search" placeholder="Search" class="w-64" />
+      <USelect
+        v-model="category"
+        :options="categoryOptions"
+        option-attribute="label"
+        value-attribute="value"
+        placeholder="Category"
+        class="w-48"
+      />
+    </div>
     <ul v-if="visibleMoneypots" class="grid grid-cols-5 gap-4 mt-8">
       <li v-for="moneypot in visibleMoneypots.pots" :key="moneypot.id">
         <NuxtLink :to="{
@@ -12,7 +23,12 @@
         </NuxtLink>
       </li>
     </ul>
-    <UPagination v-model:page="pageAsInt" show-edges :items-per-page="pageSize" :total="visibleMoneypots?.total" />
+    <UPagination
+      v-model:page="pageAsInt"
+      show-edges
+      :items-per-page="pageSize"
+      :total="visibleMoneypots?.total"
+    />
 
   </div>
 </template>
@@ -20,8 +36,8 @@
 
 <script setup lang="ts">
 import { useAsyncData } from "#app";
-import { NuxtLink, UPagination } from "#components";
-import { computed } from "vue";
+import { NuxtLink, UPagination, UInput, USelect } from "#components";
+import { computed, watch } from "vue";
 import MoneypotCard from "~/components/MoneypotCard.vue";
 import { useUrlParams } from "~/composables/useUrlParams";
 import { getUIPropsFromMoneypot } from "~/helpers/moneypotUIHelpers";
@@ -35,7 +51,25 @@ const pageAsInt = computed({
 });
 
 const pageSize = 10;
-const paginationDedupeKey = computed(() => `moneypots-list-${page}`);
+const paginationDedupeKey = computed(
+  () => `moneypots-list-${page}-${search.value}-${category.value}`,
+);
+
+const search = useUrlParams("q");
+const category = useUrlParams("category");
+
+const { data: categories } = await useAsyncData(
+  "moneypot-categories",
+  () => $fetch("/api/pots/categories"),
+);
+
+const categoryOptions = computed(() =>
+  categories.value?.map((c) => ({ label: c.slug, value: c.id })) ?? [],
+);
+
+watch([search, category], () => {
+  pageAsInt.value = 1;
+});
 
 const { data: visibleMoneypots } = useAsyncData(
   paginationDedupeKey,
@@ -44,11 +78,13 @@ const { data: visibleMoneypots } = useAsyncData(
       query: {
         pageSize: pageSize,
         page: page.value,
+        q: search.value,
+        category: category.value,
       },
     });
   },
   {
-    watch: [page],
+    watch: [page, search, category],
   },
 );
 </script>

--- a/app/pages/explore.vue
+++ b/app/pages/explore.vue
@@ -10,8 +10,8 @@
     </div>
 
     <div v-if="visibleMoneypots">
-      <div v-if="visibleMoneypots.pots.length === 0">no results</div>
-      <ul v-else class="grid grid-cols-5 gap-4 mt-8">
+      <div class="my-4 font-bold">{{ visibleMoneypots.total }} results</div>
+      <ul v-if="visibleMoneypots.pots.length > 0" class="grid grid-cols-5 gap-4">
         <li v-for="moneypot in visibleMoneypots.pots" :key="moneypot.id">
           <NuxtLinkLocale :to="{
             name: 'pots-id',

--- a/app/pages/explore.vue
+++ b/app/pages/explore.vue
@@ -1,16 +1,13 @@
 <template>
   <div>
-    <div class="flex items-end gap-4">
-      <UInput v-model="localSearch" placeholder="Search" class="w-64" />
-      <USelect
-        v-model="localCategory"
-        :options="categoryOptions"
-        option-attribute="label"
-        value-attribute="value"
-        placeholder="Category"
-        class="w-48"
-      />
-      <UButton @click="applyFilters">Search</UButton>
+    <div class="background bg-neutral-700 px-4">
+      <h1 class="text-3xl font-bold pt-4">Explore Moneypots</h1>
+      <p class="mt-2">Discover and contribute to moneypots created by others.</p>
+      <div class="flex items-end gap-2 mt-4 pb-4">
+        <UInput size="xl" v-model="localSearch" placeholder="Search" class="grow" />
+        <USelect size="xl" v-model="localCategory" :items="categoryOptions" placeholder="Category" class="w-52" />
+        <UButton size="xl" @click="applyFilters">Search</UButton>
+      </div>
     </div>
     <ul v-if="visibleMoneypots" class="grid grid-cols-5 gap-4 mt-8">
       <li v-for="moneypot in visibleMoneypots.pots" :key="moneypot.id">
@@ -24,12 +21,8 @@
         </NuxtLink>
       </li>
     </ul>
-    <UPagination
-      v-model:page="pageAsInt"
-      show-edges
-      :items-per-page="pageSize"
-      :total="visibleMoneypots?.total"
-    />
+    <UPagination class="my-6" v-model:page="pageAsInt" show-edges :items-per-page="pageSize"
+      :total="visibleMoneypots?.total" />
 
   </div>
 </template>
@@ -68,14 +61,14 @@ const applyFilters = () => {
 };
 
 const { data: categories } = await useAsyncData(
-  "moneypot-categories",
+  "moneypot-categories-explore",
   () => $fetch("/api/pots/categories"),
+  {
+    default: () => ([]),
+  }
 );
 
-const categoryOptions = computed(() => [
-  { label: "All", value: "" },
-  ...(categories.value?.map((c) => ({ label: c.slug, value: c.id })) ?? []),
-]);
+const categoryOptions = computed(() => categories.value.map((c) => ({ label: c.slug, value: c.id })));
 
 watch([search, category], () => {
   pageAsInt.value = 1;

--- a/app/pages/pots/create.vue
+++ b/app/pages/pots/create.vue
@@ -105,8 +105,8 @@ const formStep2FormData = computed(() => {
     title: titleUrl.value,
     targetAmount: targetAmount.value
       ? String(
-          converter.ether(String(targetAmount.value)),
-        ) /* formData can't use numbers */
+        converter.ether(String(targetAmount.value)),
+      ) /* formData can't use numbers */
       : "",
     description: description.value,
     categoryId: categoryId.value,
@@ -185,7 +185,7 @@ const items = ref<TimelineItem[]>([
 ]);
 
 const { data: moneypotCategories } = await useAsyncData(
-  "moneypot-categories",
+  "moneypot-categories-create",
   () => $fetch("/api/pots/categories"),
 );
 
@@ -208,8 +208,8 @@ const groupedMoneyPotCategories = computed(() =>
 const moneypotCategoriesTypes = computed(() =>
   groupedMoneyPotCategories.value
     ? (Object.keys(groupedMoneyPotCategories.value) as unknown as Array<
-        keyof typeof groupedMoneyPotCategories.value
-      >)
+      keyof typeof groupedMoneyPotCategories.value
+    >)
     : [],
 );
 

--- a/server/api/pots/list.get.ts
+++ b/server/api/pots/list.get.ts
@@ -11,8 +11,12 @@ export default defineEventHandler(async (event) => {
   const pageSize = Number(query.pageSize) > 0 ? Number(query.pageSize) : 10;
   const offset = (page - 1) * pageSize;
 
-  const search = typeof query.q === "string" ? query.q : undefined;
-  const category = typeof query.category === "string" ? query.category : undefined;
+  const search =
+    typeof query.q === "string" && query.q !== "" ? query.q : undefined;
+  const category =
+    typeof query.category === "string" && query.category !== ""
+      ? query.category
+      : undefined;
 
   const whereFilter = () => {
     if (search && category) {
@@ -28,12 +32,10 @@ export default defineEventHandler(async (event) => {
   };
 
   // Get total count for pagination
-  let totalQuery = db.select({ count: count() }).from(pots);
   const filter = whereFilter();
-  if (filter) {
-    totalQuery = totalQuery.where(filter);
-  }
-  const total = await totalQuery;
+  const total = await (filter
+    ? db.select({ count: count() }).from(pots).where(filter)
+    : db.select({ count: count() }).from(pots));
 
   // Fetch paginated pots
   const items = await db.query.pots.findMany({

--- a/server/database/migrations/0011_fast_search_index.sql
+++ b/server/database/migrations/0011_fast_search_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX pots_title_idx ON "pots" ("title");

--- a/server/database/migrations/meta/0011_snapshot.json
+++ b/server/database/migrations/meta/0011_snapshot.json
@@ -1,0 +1,625 @@
+{
+  "id": "049981a6-acea-444c-bd50-7fc74d85478d",
+  "prevId": "19da51f9-60bc-4ec4-94a1-1d2cf0ee1ac3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      "indexes": {},
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contributions": {
+      "name": "contributions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pot_id": {
+          "name": "pot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contributor_id": {
+          "name": "contributor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from": {
+          "name": "from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contributions_pot_id_pots_id_fk": {
+          "name": "contributions_pot_id_pots_id_fk",
+          "tableFrom": "contributions",
+          "tableTo": "pots",
+          "columnsFrom": ["pot_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contributions_contributor_id_user_id_fk": {
+          "name": "contributions_contributor_id_user_id_fk",
+          "tableFrom": "contributions",
+          "tableTo": "user",
+          "columnsFrom": ["contributor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "amount_must_be_positive": {
+          "name": "amount_must_be_positive",
+          "value": "\"contributions\".\"amount\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pot_category": {
+      "name": "pot_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pots": {
+      "name": "pots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_amount": {
+          "name": "target_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image": {
+          "name": "cover_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_private_key": {
+          "name": "wallet_private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+        "indexes": {
+          "pots_title_idx": {
+            "name": "pots_title_idx",
+            "unique": false,
+            "expressions": ["title"]
+          }
+        },
+      "foreignKeys": {
+        "pots_creator_id_user_id_fk": {
+          "name": "pots_creator_id_user_id_fk",
+          "tableFrom": "pots",
+          "tableTo": "user",
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pots_category_id_pot_category_id_fk": {
+          "name": "pots_category_id_pot_category_id_fk",
+          "tableFrom": "pots",
+          "tableTo": "pot_category",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "target_amount_must_be_positive": {
+          "name": "target_amount_must_be_positive",
+          "value": "\"pots\".\"target_amount\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallets_user_id_user_id_fk": {
+          "name": "wallets_user_id_user_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1752163482476,
       "tag": "0010_fair_firestar",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1752163482477,
+      "tag": "0011_fast_search_index",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add search and category filter on explore page
- keep filter state in the URL
- allow `/api/pots/list` to filter by search and category

## Testing
- `pnpm exec biome format server/api/pots/list.get.ts app/pages/explore.vue` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.4.1.tgz)*
- `pnpm typecheck` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.4.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_687058c5cc44832abb54a9d942fe8da4