### PR TITLE
Add All category option

### DIFF
--- a/app/components/ExploreFilterForm.vue
+++ b/app/components/ExploreFilterForm.vue
@@ -1,9 +1,20 @@
 <template>
   <UForm :schema="schema" :state="{ search: searchModel, category: categoryModel }" @submit="onSubmit">
     <div class="flex items-end gap-2">
-      <UInput v-model="searchModel" placeholder="Search" class="w-64 grow" size="xl" />
-      <USelect v-model="categoryModel" :items="categoryOptions" placeholder="Category" class="w-48" size="xl" />
-      <UButton type="submit" size="xl">Search</UButton>
+      <UInput
+        v-model="searchModel"
+        :placeholder="t('explore.filters.searchPlaceholder')"
+        class="w-64 grow"
+        size="xl"
+      />
+      <USelect
+        v-model="categoryModel"
+        :items="categoryOptions"
+        :placeholder="t('explore.filters.categoryPlaceholder')"
+        class="w-48"
+        size="xl"
+      />
+      <UButton type="submit" size="xl">{{ t('explore.filters.searchButton') }}</UButton>
     </div>
   </UForm>
 </template>
@@ -11,6 +22,7 @@
 <script setup lang="ts">
 import { UForm, UInput, USelect, UButton } from '#components';
 import * as z from 'zod';
+import { useI18n } from '#imports';
 
 const searchModel = defineModel<string>('search');
 const categoryModel = defineModel<string>('category');
@@ -27,6 +39,8 @@ const schema = z.object({
   search: z.string().optional(),
   category: z.string().optional(),
 });
+
+const { t } = useI18n();
 
 function onSubmit() {
   emit('submit');

--- a/app/pages/explore.vue
+++ b/app/pages/explore.vue
@@ -2,15 +2,15 @@
   <div>
     <div class="background bg-neutral-700">
       <div class="max-w-2xl mx-auto">
-        <h1 class="text-3xl font-bold pt-4">Explore Moneypots</h1>
-        <p class="mt-2">Discover and contribute to moneypots created by others.</p>
+        <h1 class="text-3xl font-bold pt-4">{{ t('explore.title') }}</h1>
+        <p class="mt-2">{{ t('explore.description') }}</p>
         <ExploreFilterForm v-model:search="localSearch" v-model:category="localCategory"
           :category-options="categoryOptions" @submit="applyFilters" class="py-4" />
       </div>
     </div>
 
     <div v-if="visibleMoneypots">
-      <div class="my-4 font-bold">{{ visibleMoneypots.total }} results</div>
+      <div class="my-4 font-bold">{{ t('explore.results', { total: visibleMoneypots.total }) }}</div>
       <ul v-if="visibleMoneypots.pots.length > 0" class="grid grid-cols-5 gap-4">
         <li v-for="moneypot in visibleMoneypots.pots" :key="moneypot.id">
           <NuxtLinkLocale :to="{
@@ -36,11 +36,14 @@
 import { useAsyncData } from "#app";
 import { NuxtLinkLocale, UPagination } from "#components";
 import { computed, watch, ref } from "vue";
+import { useI18n } from "#imports";
 import MoneypotCard from "~/components/MoneypotCard.vue";
 import ExploreFilterForm from "~/components/ExploreFilterForm.vue";
 
 import { useUrlParams } from "~/composables/useUrlParams";
 import { getUIPropsFromMoneypot } from "~/helpers/moneypotUIHelpers";
+
+const { t } = useI18n();
 
 const page = useUrlParams("page");
 const pageAsInt = computed({
@@ -74,7 +77,10 @@ const { data: categories } = await useAsyncData(
   }
 );
 
-const categoryOptions = computed(() => categories.value.map((c) => ({ label: c.slug, value: c.id })));
+const categoryOptions = computed(() => [
+  { label: t('explore.filters.all'), value: "" },
+  ...categories.value.map((c) => ({ label: c.slug, value: c.id })),
+]);
 
 watch([search, category], () => {
   pageAsInt.value = 1;

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -18,6 +18,17 @@
   "footer": {
     "openDevtools": "Open DevTools"
   },
+  "explore": {
+    "title": "Explore Moneypots",
+    "description": "Discover and contribute to moneypots created by others.",
+    "results": "{total} results",
+    "filters": {
+      "searchPlaceholder": "Search",
+      "categoryPlaceholder": "Category",
+      "searchButton": "Search",
+      "all": "All"
+    }
+  },
   "createPot": {
     "title": "Create a Moneypot",
     "errorCategories": "error loading categories",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -18,6 +18,17 @@
   "footer": {
     "openDevtools": "Ouvrir les outils de développement"
   },
+  "explore": {
+    "title": "Explorer les cagnottes",
+    "description": "Découvrez et contribuez aux cagnottes créées par d'autres.",
+    "results": "{total} résultats",
+    "filters": {
+      "searchPlaceholder": "Rechercher",
+      "categoryPlaceholder": "Catégorie",
+      "searchButton": "Rechercher",
+      "all": "Toutes"
+    }
+  },
   "createPot": {
     "title": "Créer une cagnotte",
     "errorCategories": "erreur lors du chargement des catégories",


### PR DESCRIPTION
## Summary
- update explore page filter to include an All option
- add translation entries for explore page and filter
- localize filter placeholders and labels

## Testing
- `pnpm format` *(fails: unable to download pnpm)*
- `npx biome --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687414eb7df0832aabc18e856252a5a0